### PR TITLE
Separate UAV Handler

### DIFF
--- a/include/mrs_uav_testing/test_generic.h
+++ b/include/mrs_uav_testing/test_generic.h
@@ -50,8 +50,8 @@ using namespace std;
 
 class UAVHandler {
 public: 
-  UAVHandler(std::string uav_name, mrs_lib::SubscribeHandlerOptions shopts, bool using_gazebo_sim);
-  void initialize( std::string uav_name, mrs_lib::SubscribeHandlerOptions shopts, bool using_gazebo_sim);
+  UAVHandler(std::string uav_name, mrs_lib::SubscribeHandlerOptions shopts, bool using_gazebo_sim, bool use_hw_api = true);
+  void initialize(std::string uav_name, mrs_lib::SubscribeHandlerOptions shopts, bool using_gazebo_sim, bool use_hw_api = true);
 
 
   tuple<bool, string> spawn(string gazebo_spawner_params);
@@ -142,6 +142,8 @@ protected:
   mrs_lib::SubscribeHandlerOptions shopts_;
   ros::NodeHandle                       nh_;
   string name_;
+
+  bool use_hw_api_ = true;
 };
 
 class TestGeneric {

--- a/include/mrs_uav_testing/test_generic.h
+++ b/include/mrs_uav_testing/test_generic.h
@@ -36,6 +36,9 @@
 #include <std_srvs/SetBool.h>
 #include <std_srvs/Trigger.h>
 
+
+#include <gazebo_msgs/ModelState.h>
+
 //}
 
 namespace mrs_uav_testing
@@ -84,6 +87,9 @@ public:
   std::optional<double>                        getHeightAgl(void);
   std::optional<mrs_msgs::DynamicsConstraints> getCurrentConstraints(void);
 
+
+  tuple<bool, string> moveTo(double x, double y, double z, double hdg);
+
   tuple<bool, string> setPathSrv(const mrs_msgs::Path &path_in);
   tuple<bool, string> setPathTopic(const mrs_msgs::Path &path_in);
   tuple<bool, string> switchEstimator(const std::string &estimator);
@@ -91,6 +97,8 @@ public:
   tuple<std::optional<mrs_msgs::TrajectoryReference>, string> getPathSrv(const mrs_msgs::Path &path_in);
   
   bool mrsSystemReady(void);
+
+  
 
 protected:
 
@@ -130,6 +138,8 @@ protected:
 
   mrs_lib::SubscribeHandler<mrs_msgs::HwApiStatus> sh_hw_api_status_;
 
+
+  mrs_lib::PublisherHandler<gazebo_msgs::ModelState> ph_gazebo_model_state_;
 
   bool initialized_ = false;
   bool spawned_ = false;

--- a/include/mrs_uav_testing/test_generic.h
+++ b/include/mrs_uav_testing/test_generic.h
@@ -156,41 +156,7 @@ public:
   std::shared_ptr<mrs_lib::ParamLoader> pl_;
 
   UAVHandler makeUAV(string uav_name);
- //TODO: the below uses the default DroneMangager - deprecate, this should be specific for a drone {
-
   bool isGazeboSimulation(void);
-
-  tuple<bool, string> takeoff(void);
-  tuple<bool, string> land(void);
-  tuple<bool, string> landHome(void);
-  tuple<bool, string> activateMidAir(void);
-
-  tuple<bool, string> gotoAbs(const double &x, const double &y, const double &z, const double &hdg);
-  tuple<bool, string> gotoRel(const double &x, const double &y, const double &z, const double &hdg);
-  tuple<bool, string> gotoTrajectoryStart();
-  tuple<bool, string> startTrajectoryTracking();
-  tuple<bool, string> resumeTrajectoryTracking();
-  tuple<bool, string> stopTrajectoryTracking();
-
-  bool hasGoal(void);
-  bool isFlyingNormally(void);
-  bool isOutputEnabled(void);
-  bool isAtPosition(const double &x, const double &y, const double &z, const double &hdg, const double &pos_tolerance);
-  bool isReferenceAtPosition(const double &x, const double &y, const double &z, const double &hdg, const double &pos_tolerance);
-
-  std::string                                  getActiveTracker(void);
-  std::string                                  getActiveController(void);
-  std::string                                  getActiveEstimator(void);
-  std::optional<mrs_msgs::TrackerCommand>      getTrackerCmd(void);
-  std::optional<double>                        getHeightAgl(void);
-  std::optional<mrs_msgs::DynamicsConstraints> getCurrentConstraints(void);
-
-  tuple<bool, string> setPathSrv(const mrs_msgs::Path &path_in);
-  tuple<bool, string> setPathTopic(const mrs_msgs::Path &path_in);
-  tuple<bool, string> switchEstimator(const std::string &estimator);
-
-  tuple<std::optional<mrs_msgs::TrajectoryReference>, string> getPathSrv(const mrs_msgs::Path &path_in);
-  //}
 
 protected:
   ros::NodeHandle                       nh_;
@@ -207,8 +173,6 @@ protected:
   string name_;
 
   bool mrsSystemReady(void);
-
-  std::unique_ptr<UAVHandler> uh; //the default drone manager, for compatibility, but user of TestGeneric should use his own so we can deprecate this.
 
 private:
   shared_ptr<ros::AsyncSpinner> spinner_;

--- a/include/mrs_uav_testing/test_generic.h
+++ b/include/mrs_uav_testing/test_generic.h
@@ -136,7 +136,7 @@ protected:
 
   string _uav_name_;
 
-  bool is_gazebo_simulation_;
+  bool is_gazebo_simulation_ = false;
   string _gazebo_spawner_params_;
 
   mrs_lib::SubscribeHandlerOptions shopts_;
@@ -164,7 +164,7 @@ protected:
 
   mrs_lib::SubscribeHandlerOptions shopts_;
 
-  bool is_gazebo_simulation_;
+  bool is_gazebo_simulation_ = false;
 
   string _uav_name_; //TODO: remove, should be UAVHandler specific
   string _gazebo_spawner_params_; //TODO: remove, should be UAVHandler specific

--- a/include/mrs_uav_testing/test_generic.h
+++ b/include/mrs_uav_testing/test_generic.h
@@ -157,7 +157,7 @@ public:
 
   std::shared_ptr<mrs_lib::ParamLoader> pl_;
 
-  std::tuple<std::optional<UAVHandler>,string> makeUAV(string uav_name);
+  std::tuple<std::optional<UAVHandler>,string> makeUAV(string uav_name, bool use_hw_api = true);
   bool isGazeboSimulation(void);
 
 protected:

--- a/include/mrs_uav_testing/test_generic.h
+++ b/include/mrs_uav_testing/test_generic.h
@@ -155,7 +155,7 @@ public:
 
   std::shared_ptr<mrs_lib::ParamLoader> pl_;
 
-  UAVHandler makeUAV(string uav_name);
+  std::tuple<std::optional<UAVHandler>,string> makeUAV(string uav_name);
   bool isGazeboSimulation(void);
 
 protected:
@@ -171,6 +171,9 @@ protected:
 
   string _test_name_;
   string name_;
+
+
+  bool initialized_ = false;
 
   bool mrsSystemReady(void);
 

--- a/include/mrs_uav_testing/test_generic.h
+++ b/include/mrs_uav_testing/test_generic.h
@@ -40,19 +40,23 @@
 
 namespace mrs_uav_testing
 {
+  
+void sleep(const double &duration);
 
 using radians  = mrs_lib::geometry::radians;
 using sradians = mrs_lib::geometry::sradians;
 
 using namespace std;
 
-class DroneManager {
+class UAVHandler {
 public: 
-  DroneManager(std::string spawner_params, std::string uav_name, mrs_lib::SubscribeHandlerOptions shopts);
-  void initialize(std::string spawner_params, std::string uav_name, mrs_lib::SubscribeHandlerOptions shopts);
+  UAVHandler(std::string uav_name, mrs_lib::SubscribeHandlerOptions shopts, bool using_gazebo_sim);
+  void initialize( std::string uav_name, mrs_lib::SubscribeHandlerOptions shopts, bool using_gazebo_sim);
 
 
-  tuple<bool, string> spawn();
+  tuple<bool, string> spawn(string gazebo_spawner_params);
+
+  tuple<bool, string> checkConditions(void);
 
   //TODO: consider if we need to add initialization checks
   tuple<bool, string> takeoff(void);
@@ -127,8 +131,12 @@ protected:
   mrs_lib::SubscribeHandler<mrs_msgs::HwApiStatus> sh_hw_api_status_;
 
 
+  bool initialized_ = false;
+  bool spawned_ = false;
 
   string _uav_name_;
+
+  bool is_gazebo_simulation_;
   string _gazebo_spawner_params_;
 
   mrs_lib::SubscribeHandlerOptions shopts_;
@@ -147,8 +155,10 @@ public:
 
   std::shared_ptr<mrs_lib::ParamLoader> pl_;
 
+  UAVHandler makeUAV(string uav_name);
  //TODO: the below uses the default DroneMangager - deprecate, this should be specific for a drone {
-  tuple<bool, string> spawnGazeboUav();
+
+  bool isGazeboSimulation(void);
 
   tuple<bool, string> takeoff(void);
   tuple<bool, string> land(void);
@@ -188,19 +198,17 @@ protected:
 
   mrs_lib::SubscribeHandlerOptions shopts_;
 
+  bool is_gazebo_simulation_;
 
-  void sleep(const double &duration);
-
-
-  string _uav_name_; //TODO: remove, should be DroneManager specific
-  string _gazebo_spawner_params_; //TODO: remove, should be DroneManager specific
+  string _uav_name_; //TODO: remove, should be UAVHandler specific
+  string _gazebo_spawner_params_; //TODO: remove, should be UAVHandler specific
 
   string _test_name_;
   string name_;
 
   bool mrsSystemReady(void);
 
-  std::unique_ptr<DroneManager> dm; //the default drone manager, for compatibility, but user of TestGeneric should use his own so we can deprecate this.
+  std::unique_ptr<UAVHandler> uh; //the default drone manager, for compatibility, but user of TestGeneric should use his own so we can deprecate this.
 
 private:
   shared_ptr<ros::AsyncSpinner> spinner_;

--- a/src/test_generic.cpp
+++ b/src/test_generic.cpp
@@ -113,13 +113,6 @@ void TestGeneric::initialize(void) {
   shopts_.queue_size         = 10;
   shopts_.transport_hints    = ros::TransportHints().tcpNoDelay();
 
-  // | ------------------ prepare the default uh ---------------- |
-
-  uh = std::make_unique<UAVHandler>(makeUAV("uav1"));
-  if (isGazeboSimulation()){
-    uh->spawn(_gazebo_spawner_params_);
-  }
-
   // | --------------------- finish the init -------------------- |
 
   ROS_INFO("[%s]: initialized", name_.c_str());
@@ -269,10 +262,6 @@ void sleep(const double &duration) {
 //}
 
 /* takeoff() //{ */
-tuple<bool, string> TestGeneric::takeoff(void) {
-  return uh->takeoff();
-}
-
 tuple<bool, string> UAVHandler::takeoff(void) {
   auto res = checkConditions();
   if (!(std::get<0>(res)))
@@ -380,11 +369,6 @@ tuple<bool, string> UAVHandler::takeoff(void) {
 //}
 
 /* land() //{ */
-
-tuple<bool, string> TestGeneric::land(void) {
-  return uh->land();
-}
-
 tuple<bool, string> UAVHandler::land(void) {
   auto res = checkConditions();
   if (!(std::get<0>(res)))
@@ -453,10 +437,6 @@ tuple<bool, string> UAVHandler::land(void) {
 //}
 
 /* landHome() //{ */
-tuple<bool, string> TestGeneric::landHome(void) {
-  return uh->landHome();
-}
-
 tuple<bool, string> UAVHandler::landHome(void) {
   auto res = checkConditions();
   if (!(std::get<0>(res)))
@@ -524,11 +504,6 @@ tuple<bool, string> UAVHandler::landHome(void) {
 //}
 
 /* activateMidAir() //{ */
-tuple<bool, string> TestGeneric::activateMidAir(void) {
-  ROS_ERROR_STREAM("[" << ros::this_node::getName().c_str() << "]: Here A");
-  return uh->activateMidAir();
-}
-
 tuple<bool, string> UAVHandler::activateMidAir(void) {
   auto res = checkConditions();
   if (!(std::get<0>(res)))
@@ -619,10 +594,6 @@ tuple<bool, string> UAVHandler::activateMidAir(void) {
 //}
 
 /* gotoAbs() //{ */
-tuple<bool, string> TestGeneric::gotoAbs(const double &x, const double &y, const double &z, const double &hdg) {
-  return uh->gotoAbs(x,y,z,hdg);
-}
-
 tuple<bool, string> UAVHandler::gotoAbs(const double &x, const double &y, const double &z, const double &hdg) {
   auto res = checkConditions();
   if (!(std::get<0>(res)))
@@ -669,10 +640,6 @@ tuple<bool, string> UAVHandler::gotoAbs(const double &x, const double &y, const 
 //}
 
 /* gotoRel() //{ */
-tuple<bool, string> TestGeneric::gotoRel(const double &x, const double &y, const double &z, const double &hdg) {
-  return uh->gotoRel(x,y,z,hdg);
-}
-
 tuple<bool, string> UAVHandler::gotoRel(const double &x, const double &y, const double &z, const double &hdg) {
   auto res = checkConditions();
   if (!(std::get<0>(res)))
@@ -723,10 +690,6 @@ tuple<bool, string> UAVHandler::gotoRel(const double &x, const double &y, const 
 //}
 
 /* setPathSrv() //{ */
-tuple<bool, string> TestGeneric::setPathSrv(const mrs_msgs::Path &path_in) {
-  return uh->setPathSrv(path_in);
-}
-
 tuple<bool, string> UAVHandler::setPathSrv(const mrs_msgs::Path &path_in) {
   auto res = checkConditions();
   if (!(std::get<0>(res)))
@@ -749,10 +712,6 @@ tuple<bool, string> UAVHandler::setPathSrv(const mrs_msgs::Path &path_in) {
 //}
 
 /* setPathTopic() //{ */
-tuple<bool, string> TestGeneric::setPathTopic(const mrs_msgs::Path &path_in) {
-  return uh->setPathTopic(path_in);
-}
-
 tuple<bool, string> UAVHandler::setPathTopic(const mrs_msgs::Path &path_in) {
   auto res = checkConditions();
   if (!(std::get<0>(res)))
@@ -766,10 +725,6 @@ tuple<bool, string> UAVHandler::setPathTopic(const mrs_msgs::Path &path_in) {
 //}
 
 /* switchEstimator() //{ */
-tuple<bool, string> TestGeneric::switchEstimator(const std::string &estimator) {
-  return uh->switchEstimator(estimator);
-}
-
 tuple<bool, string> UAVHandler::switchEstimator(const std::string &estimator) {
   auto res = checkConditions();
   if (!(std::get<0>(res)))
@@ -792,10 +747,6 @@ tuple<bool, string> UAVHandler::switchEstimator(const std::string &estimator) {
 //}
 
 /* gotoTrajectoryStart() //{ */
-tuple<bool, string> TestGeneric::gotoTrajectoryStart() {
-  return uh->gotoTrajectoryStart();
-}
-
 tuple<bool, string> UAVHandler::gotoTrajectoryStart() {
   auto res = checkConditions();
   if (!(std::get<0>(res)))
@@ -840,10 +791,6 @@ tuple<bool, string> UAVHandler::gotoTrajectoryStart() {
 //}
 
 /* startTrajectoryTracking() //{ */
-tuple<bool, string> TestGeneric::startTrajectoryTracking() {
-  return uh->startTrajectoryTracking();
-}
-
 tuple<bool, string> UAVHandler::startTrajectoryTracking() {
   auto res = checkConditions();
   if (!(std::get<0>(res)))
@@ -873,10 +820,6 @@ tuple<bool, string> UAVHandler::startTrajectoryTracking() {
 //}
 
 /* stopTrajectoryTracking() //{ */
-tuple<bool, string> TestGeneric::stopTrajectoryTracking() {
-  return uh->stopTrajectoryTracking();
-}
-
 tuple<bool, string> UAVHandler::stopTrajectoryTracking() {
   auto res = checkConditions();
   if (!(std::get<0>(res)))
@@ -906,10 +849,6 @@ tuple<bool, string> UAVHandler::stopTrajectoryTracking() {
 //}
 
 /* resumeTrajectoryTracking() //{ */
-tuple<bool, string> TestGeneric::resumeTrajectoryTracking() {
-  return uh->resumeTrajectoryTracking();
-}
-
 tuple<bool, string> UAVHandler::resumeTrajectoryTracking() {
   auto res = checkConditions();
   if (!(std::get<0>(res)))
@@ -939,10 +878,6 @@ tuple<bool, string> UAVHandler::resumeTrajectoryTracking() {
 //}
 
 /* getPathSrv() //{ */
-tuple<std::optional<mrs_msgs::TrajectoryReference>, string> TestGeneric::getPathSrv(const mrs_msgs::Path &path_in) {
-  return uh->getPathSrv(path_in);
-}
-
 tuple<std::optional<mrs_msgs::TrajectoryReference>, string> UAVHandler::getPathSrv(const mrs_msgs::Path &path_in) {
   auto res = checkConditions();
   if (!(std::get<0>(res)))
@@ -967,10 +902,6 @@ tuple<std::optional<mrs_msgs::TrajectoryReference>, string> UAVHandler::getPathS
 // | ------------------------- getters ------------------------ |
 
 /* getHeightAgl() //{ */
-std::optional<double> TestGeneric::getHeightAgl(void) {
-  return uh->getHeightAgl();
-}
-
 std::optional<double> UAVHandler::getHeightAgl(void) {
   auto res = checkConditions();
   if (!(std::get<0>(res)))
@@ -986,10 +917,6 @@ std::optional<double> UAVHandler::getHeightAgl(void) {
 //}
 
 /* getCurrentConstraints() //{ */
-std::optional<mrs_msgs::DynamicsConstraints> TestGeneric::getCurrentConstraints(void) {
-  return uh->getCurrentConstraints();
-}
-
 std::optional<mrs_msgs::DynamicsConstraints> UAVHandler::getCurrentConstraints(void) {
   auto res = checkConditions();
   if (!(std::get<0>(res)))
@@ -1005,10 +932,6 @@ std::optional<mrs_msgs::DynamicsConstraints> UAVHandler::getCurrentConstraints(v
 //}
 
 /* getTrackerCmd() //{ */
-std::optional<mrs_msgs::TrackerCommand> TestGeneric::getTrackerCmd(void) {
-  return uh->getTrackerCmd();
-}
-
 std::optional<mrs_msgs::TrackerCommand> UAVHandler::getTrackerCmd(void) {
   auto res = checkConditions();
   if (!(std::get<0>(res)))
@@ -1024,10 +947,6 @@ std::optional<mrs_msgs::TrackerCommand> UAVHandler::getTrackerCmd(void) {
 //}
 
 /* isAtPosition() //{ */
-bool TestGeneric::isAtPosition(const double &x, const double &y, const double &z, const double &hdg, const double &pos_tolerance) {
-  return uh->isAtPosition(x,y,z,hdg,pos_tolerance);
-}
-
 bool UAVHandler::isAtPosition(const double &x, const double &y, const double &z, const double &hdg, const double &pos_tolerance) {
   auto res = checkConditions();
   if (!(std::get<0>(res)))
@@ -1055,10 +974,6 @@ bool UAVHandler::isAtPosition(const double &x, const double &y, const double &z,
 //}
 
 /* isReferenceAtPosition() //{ */
-bool TestGeneric::isReferenceAtPosition(const double &x, const double &y, const double &z, const double &hdg, const double &pos_tolerance) {
-  return uh->isReferenceAtPosition(x,y,z,hdg,pos_tolerance);
-}
-
 bool UAVHandler::isReferenceAtPosition(const double &x, const double &y, const double &z, const double &hdg, const double &pos_tolerance) {
 
   if (!sh_tracker_cmd_.hasMsg()) {
@@ -1081,10 +996,6 @@ bool UAVHandler::isReferenceAtPosition(const double &x, const double &y, const d
 //}
 
 /* getActiveTracker() //{ */
-std::string TestGeneric::getActiveTracker(void) {
-  return uh->getActiveTracker();
-}
-
 std::string UAVHandler::getActiveTracker(void) {
 
   if (!sh_control_manager_diag_.getMsg()) {
@@ -1097,10 +1008,6 @@ std::string UAVHandler::getActiveTracker(void) {
 //}
 
 /* getActiveController() //{ */
-std::string TestGeneric::getActiveController(void) {
-  return uh->getActiveController();
-}
-
 std::string UAVHandler::getActiveController(void) {
 
   if (!sh_control_manager_diag_.getMsg()) {
@@ -1113,10 +1020,6 @@ std::string UAVHandler::getActiveController(void) {
 //}
 
 /* getActiveEstimator() //{ */
-std::string TestGeneric::getActiveEstimator(void) {
-  return uh->getActiveEstimator();
-}
-
 std::string UAVHandler::getActiveEstimator(void) {
 
   if (!sh_estim_manager_diag_.getMsg()) {
@@ -1129,10 +1032,6 @@ std::string UAVHandler::getActiveEstimator(void) {
 //}
 
 /* hasGoal() //{ */
-bool TestGeneric::hasGoal(void) {
-  return uh->hasGoal();
-}
-
 bool UAVHandler::hasGoal(void) {
 
   if (sh_control_manager_diag_.hasMsg()) {
@@ -1145,10 +1044,6 @@ bool UAVHandler::hasGoal(void) {
 //}
 
 /* mrsSystemReady() //{ */
-bool TestGeneric::mrsSystemReady(void) {
-  return uh->mrsSystemReady();
-}
-
 bool UAVHandler::mrsSystemReady(void) {
 
   bool got_control_manager_diag    = sh_control_manager_diag_.hasMsg();
@@ -1165,10 +1060,6 @@ bool UAVHandler::mrsSystemReady(void) {
 //}
 
 /* isFlyingNormally() //{ */
-bool TestGeneric::isFlyingNormally(void) {
-  return uh->isFlyingNormally();
-}
-
 bool UAVHandler::isFlyingNormally(void) {
 
   if (sh_control_manager_diag_.hasMsg()) {
@@ -1181,10 +1072,6 @@ bool UAVHandler::isFlyingNormally(void) {
 //}
 
 /* isOutputEnabled() //{ */
-bool TestGeneric::isOutputEnabled(void) {
-  return uh->isOutputEnabled();
-}
-
 bool UAVHandler::isOutputEnabled(void) {
 
   if (sh_control_manager_diag_.hasMsg()) {

--- a/src/test_generic.cpp
+++ b/src/test_generic.cpp
@@ -188,9 +188,7 @@ tuple<bool, string> UAVHandler::spawn(string gazebo_spawner_params){
 
     ROS_INFO_THROTTLE(1.0, "[%s]: waiting for the hw API", name_.c_str());
 
-    ROS_INFO_STREAM("Waiting for the hw API A");
     if (sh_hw_api_status_.hasMsg()) {
-    ROS_INFO_STREAM("Waiting for the hw API B");
       if (sh_hw_api_status_.getMsg()->connected) {
         break;
       }

--- a/src/test_generic.cpp
+++ b/src/test_generic.cpp
@@ -250,12 +250,12 @@ bool TestGeneric::isGazeboSimulation(void) {
 //}
 
 /* makeUAV() //{ */
-std::tuple<std::optional<UAVHandler>,string> TestGeneric::makeUAV(string uav_name) {
+std::tuple<std::optional<UAVHandler>,string> TestGeneric::makeUAV(string uav_name, bool use_hw_api) {
   if (!initialized_){
     return {std::nullopt, string("Can not spawn " + uav_name + " - testing is not initialized yet!")};
   }
   else
-    return {UAVHandler(uav_name, shopts_, isGazeboSimulation()), "Success!"};
+    return {UAVHandler(uav_name, shopts_, isGazeboSimulation(), use_hw_api), "Success!"};
 }
 //}
 

--- a/src/test_generic.cpp
+++ b/src/test_generic.cpp
@@ -115,6 +115,7 @@ void TestGeneric::initialize(void) {
 
   // | --------------------- finish the init -------------------- |
 
+  initialized_ = true;
   ROS_INFO("[%s]: initialized", name_.c_str());
 }
 
@@ -187,7 +188,9 @@ tuple<bool, string> UAVHandler::spawn(string gazebo_spawner_params){
 
     ROS_INFO_THROTTLE(1.0, "[%s]: waiting for the hw API", name_.c_str());
 
+    ROS_INFO_STREAM("Waiting for the hw API A");
     if (sh_hw_api_status_.hasMsg()) {
+    ROS_INFO_STREAM("Waiting for the hw API B");
       if (sh_hw_api_status_.getMsg()->connected) {
         break;
       }
@@ -245,8 +248,12 @@ bool TestGeneric::isGazeboSimulation(void) {
 //}
 
 /* makeUAV() //{ */
-UAVHandler TestGeneric::makeUAV(string uav_name) {
-  return UAVHandler(uav_name, shopts_, isGazeboSimulation());;
+std::tuple<std::optional<UAVHandler>,string> TestGeneric::makeUAV(string uav_name) {
+  if (!initialized_){
+    return {std::nullopt, string("Can not spawn " + uav_name + " - testing is not initialized yet!")};
+  }
+  else
+    return {UAVHandler(uav_name, shopts_, isGazeboSimulation()), "Success!"};
 }
 //}
 

--- a/src/test_generic.cpp
+++ b/src/test_generic.cpp
@@ -3,12 +3,12 @@
 namespace mrs_uav_testing
 {
 
-UAVHandler::UAVHandler(std::string uav_name, mrs_lib::SubscribeHandlerOptions shopts, bool using_gazebo_sim){
+UAVHandler::UAVHandler(std::string uav_name, mrs_lib::SubscribeHandlerOptions shopts, bool using_gazebo_sim, bool use_hw_api){
 
-  initialize( uav_name, shopts, using_gazebo_sim);
+  initialize( uav_name, shopts, using_gazebo_sim, use_hw_api);
 }
 
-void UAVHandler::initialize(std::string uav_name, mrs_lib::SubscribeHandlerOptions shopts, bool using_gazebo_sim){
+void UAVHandler::initialize(std::string uav_name, mrs_lib::SubscribeHandlerOptions shopts, bool using_gazebo_sim, bool use_hw_api){
 
   _uav_name_ = uav_name;
   shopts_ = shopts;
@@ -16,6 +16,8 @@ void UAVHandler::initialize(std::string uav_name, mrs_lib::SubscribeHandlerOptio
   name_ = shopts.node_name;
 
   is_gazebo_simulation_ = using_gazebo_sim;
+
+  use_hw_api_ = use_hw_api;
 
   sh_control_manager_diag_ = mrs_lib::SubscribeHandler<mrs_msgs::ControlManagerDiagnostics>(shopts_, "/" + _uav_name_ + "/control_manager/diagnostics");
   sh_current_constraints_  = mrs_lib::SubscribeHandler<mrs_msgs::DynamicsConstraints>(shopts_, "/" + _uav_name_ + "/control_manager/current_constraints");
@@ -178,6 +180,7 @@ tuple<bool, string> UAVHandler::spawn(string gazebo_spawner_params){
     sleep(0.01);
   }
 
+  if (use_hw_api_){
   // | ------------- wait for the HW API to connect ------------- |
 
   while (true) {
@@ -198,6 +201,7 @@ tuple<bool, string> UAVHandler::spawn(string gazebo_spawner_params){
   }
 
   // | -------------- wait for PX4 to finish bootup ------------- |
+  }
 
   sleep(20.0);
 

--- a/test/goto/test.cpp
+++ b/test/goto/test.cpp
@@ -10,8 +10,13 @@ public:
 
 bool Tester::test() {
 
+  auto uh = makeUAV(_uav_name_);
+  if (isGazeboSimulation()){
+    uh.spawn(_gazebo_spawner_params_);
+  }
+
   {
-    auto [success, message] = activateMidAir();
+    auto [success, message] = uh.activateMidAir();
 
     if (!success) {
       ROS_ERROR("[%s]: midair activation failed with message: '%s'", ros::this_node::getName().c_str(), message.c_str());
@@ -20,7 +25,7 @@ bool Tester::test() {
   }
 
   {
-    auto [success, message] = this->gotoAbs(0, 0, 2.0, 0);
+    auto [success, message] = uh.gotoAbs(0, 0, 2.0, 0);
 
     if (!success) {
       ROS_ERROR("[%s]: goto failed with message: '%s'", ros::this_node::getName().c_str(), message.c_str());
@@ -30,7 +35,7 @@ bool Tester::test() {
 
   sleep(5.0);
 
-  if (this->isFlyingNormally()) {
+  if (uh.isFlyingNormally()) {
     return true;
   } else {
     ROS_ERROR("[%s]: not flying normally", ros::this_node::getName().c_str());

--- a/test/goto/test.cpp
+++ b/test/goto/test.cpp
@@ -28,7 +28,7 @@ bool Tester::test() {
     }
   }
 
-  this->sleep(5.0);
+  sleep(5.0);
 
   if (this->isFlyingNormally()) {
     return true;

--- a/test/goto/test.cpp
+++ b/test/goto/test.cpp
@@ -10,7 +10,13 @@ public:
 
 bool Tester::test() {
 
-  auto uh = makeUAV(_uav_name_);
+  auto [uho, uh_message] = makeUAV(_uav_name_);
+  if (uho == std::nullopt){
+    ROS_ERROR("[%s]: Failed to create uav %s: %s", ros::this_node::getName().c_str(), _uav_name_.c_str(), uh_message.c_str());
+    return false;
+  }
+  auto uh = *std::move(uho);
+
   if (isGazeboSimulation()){
     uh.spawn(_gazebo_spawner_params_);
   }

--- a/test/goto_relative/test.cpp
+++ b/test/goto_relative/test.cpp
@@ -28,7 +28,7 @@ bool Tester::test() {
     }
   }
 
-  this->sleep(5.0);
+  sleep(5.0);
 
   if (this->isFlyingNormally()) {
     return true;

--- a/test/goto_relative/test.cpp
+++ b/test/goto_relative/test.cpp
@@ -10,10 +10,12 @@ public:
 
 bool Tester::test() {
 
-  auto uh = makeUAV(_uav_name_);
-  if (isGazeboSimulation()){
-    uh.spawn(_gazebo_spawner_params_);
+  auto [uho, uh_message] = makeUAV(_uav_name_);
+  if (uho == std::nullopt){
+    ROS_ERROR("[%s]: Failed to create uav %s: %s", ros::this_node::getName().c_str(), _uav_name_.c_str(), uh_message.c_str());
+    return false;
   }
+  auto uh = *std::move(uho);
 
   {
     auto [success, message] = uh.activateMidAir();

--- a/test/goto_relative/test.cpp
+++ b/test/goto_relative/test.cpp
@@ -10,8 +10,13 @@ public:
 
 bool Tester::test() {
 
+  auto uh = makeUAV(_uav_name_);
+  if (isGazeboSimulation()){
+    uh.spawn(_gazebo_spawner_params_);
+  }
+
   {
-    auto [success, message] = activateMidAir();
+    auto [success, message] = uh.activateMidAir();
 
     if (!success) {
       ROS_ERROR("[%s]: midair activation failed with message: '%s'", ros::this_node::getName().c_str(), message.c_str());
@@ -20,7 +25,7 @@ bool Tester::test() {
   }
 
   {
-    auto [success, message] = this->gotoRel(1, 2, 3, 1);
+    auto [success, message] = uh.gotoRel(1, 2, 3, 1);
 
     if (!success) {
       ROS_ERROR("[%s]: goto relative failed with message: '%s'", ros::this_node::getName().c_str(), message.c_str());
@@ -30,7 +35,7 @@ bool Tester::test() {
 
   sleep(5.0);
 
-  if (this->isFlyingNormally()) {
+  if (uh.isFlyingNormally()) {
     return true;
   } else {
     ROS_ERROR("[%s]: not flying normally", ros::this_node::getName().c_str());

--- a/test/takeoff/test.cpp
+++ b/test/takeoff/test.cpp
@@ -10,10 +10,12 @@ public:
 
 bool Tester::test() {
 
-  auto uh = makeUAV(_uav_name_);
-  if (isGazeboSimulation()){
-    uh.spawn(_gazebo_spawner_params_);
+  auto [uho, uh_message] = makeUAV(_uav_name_);
+  if (uho == std::nullopt){
+    ROS_ERROR("[%s]: Failed to create uav %s: %s", ros::this_node::getName().c_str(), _uav_name_.c_str(), uh_message.c_str());
+    return false;
   }
+  auto uh = *std::move(uho);
 
 
   auto [success, message] = uh.takeoff();

--- a/test/takeoff/test.cpp
+++ b/test/takeoff/test.cpp
@@ -10,7 +10,13 @@ public:
 
 bool Tester::test() {
 
-  auto [success, message] = takeoff();
+  auto uh = makeUAV(_uav_name_);
+  if (isGazeboSimulation()){
+    uh.spawn(_gazebo_spawner_params_);
+  }
+
+
+  auto [success, message] = uh.takeoff();
 
   if (!success) {
     ROS_ERROR("[%s]: takeoff failed with message: '%s'", ros::this_node::getName().c_str(), message.c_str());
@@ -19,7 +25,7 @@ bool Tester::test() {
 
   sleep(5.0);
 
-  if (this->isFlyingNormally()) {
+  if (uh.isFlyingNormally()) {
     return true;
   } else {
     ROS_ERROR("[%s]: not flying normally", ros::this_node::getName().c_str());

--- a/test/takeoff/test.cpp
+++ b/test/takeoff/test.cpp
@@ -17,7 +17,7 @@ bool Tester::test() {
     return false;
   }
 
-  this->sleep(5.0);
+  sleep(5.0);
 
   if (this->isFlyingNormally()) {
     return true;


### PR DESCRIPTION
Separated a structure that handles individual drones in the simulation.
Methods such as `takeoff()` , `isFlyingNormally()` or `switchEstimator(const std::string &estimator)` are now implemented per-drone, allowing the user to control multiple drones in the simulation.
The testing procedure therefore needs to initialize a drone before using it.