### PR TITLE
Update CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.28)
 project(mrs_uav_testing)
 
 set(CMAKE_CXX_STANDARD 20)
@@ -26,32 +26,35 @@ set(DEPENDENCIES
   mrs_msgs
   tf2_ros
   backward_ros
-  )
-
-set(LIBRARIES
-  MrsUavTesting_TestGeneric
-  )
+)
 
 foreach(DEP IN LISTS DEPENDENCIES)
   find_package(${DEP} REQUIRED)
 endforeach()
 
-include_directories(
-  include
-  ${rclcpp_INCLUDE_DIRS}
-  ${mrs_lib_INCLUDE_DIRS}
-  )
+add_library(MrsUavTesting_MrsUavTesting)
+add_library(mrs_uav_testing::mrs_uav_testing ALIAS MrsUavTesting_MrsUavTesting)
+set_target_properties(MrsUavTesting_MrsUavTesting
+  PROPERTIES
+    EXPORT_NAME mrs_uav_testing
+    OUTPUT_NAME mrs_uav_testing
+)
 
-# Test Generic
+target_sources(MrsUavTesting_MrsUavTesting
+  PRIVATE
+    "src/test_generic.cpp"
+  PUBLIC FILE_SET HEADERS BASE_DIRS "include"
+  FILES
+    "include/mrs_uav_testing/test_generic.h"
+)
 
-add_library(MrsUavTesting_TestGeneric
-  src/test_generic.cpp
-  )
-
-ament_target_dependencies(MrsUavTesting_TestGeneric
-  rclcpp
-  mrs_lib
-  )
+target_link_libraries(MrsUavTesting_MrsUavTesting
+  PUBLIC
+    rclcpp::rclcpp
+    mrs_lib::mrs_lib
+    tf2_ros::tf2_ros
+    ${mrs_msgs_TARGETS}
+)
 
 ## --------------------------------------------------------------
 ## |                           Testing                          |
@@ -67,21 +70,13 @@ endif()
 ## |                           install                          |
 ## --------------------------------------------------------------
 
-ament_export_libraries(
-  ${LIBRARIES}
-)
-
-install(TARGETS
-  ${LIBRARIES}
+install(
+  TARGETS MrsUavTesting_MrsUavTesting
   EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
-)
-
-install(
-  DIRECTORY include
-  DESTINATION .
+  FILE_SET HEADERS DESTINATION "include/${PROJECT_NAME}"
 )
 
 install(
@@ -94,12 +89,16 @@ install(
   DESTINATION share/${PROJECT_NAME}
 )
 
-ament_export_include_directories(
-  include
-)
-
 ament_export_targets(
   export_${PROJECT_NAME} HAS_LIBRARY_TARGET
+)
+
+ament_export_include_directories(
+  "include/${PROJECT_NAME}"
+)
+
+ament_export_libraries(
+  MrsUavTesting_MrsUavTesting
 )
 
 ament_export_dependencies(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,8 +7,8 @@ function(add_ros_isolated_launch_test path)
   add_launch_test("${path}" RUNNER "${RUNNER}" ${ARGN})
 endfunction()
 
-add_subdirectory(./takeoff)
+add_subdirectory(takeoff)
 
-add_subdirectory(./goto_absolute)
+add_subdirectory(goto_absolute)
 
-add_subdirectory(./goto_relative)
+add_subdirectory(goto_relative)

--- a/test/goto_absolute/CMakeLists.txt
+++ b/test/goto_absolute/CMakeLists.txt
@@ -2,21 +2,19 @@ get_filename_component(TEST_NAME "${CMAKE_CURRENT_SOURCE_DIR}" NAME)
 
 add_executable(test_${TEST_NAME}
   test.cpp
-  )
-
-ament_target_dependencies(test_${TEST_NAME}
-  rclcpp
-  mrs_lib
-  mrs_msgs
-  )
+)
 
 target_link_libraries(test_${TEST_NAME}
-    MrsUavTesting_TestGeneric
-  )
+  PRIVATE
+    mrs_uav_testing::mrs_uav_testing
+    rclcpp::rclcpp
+    mrs_lib::mrs_lib
+    ${mrs_msgs_TARGETS}
+)
 
-install(TARGETS
-  test_${TEST_NAME}
+install(
+  TARGETS test_${TEST_NAME}
   DESTINATION lib/${PROJECT_NAME}
-  )
+)
 
 add_ros_isolated_launch_test(test.py TIMEOUT 300)

--- a/test/goto_relative/CMakeLists.txt
+++ b/test/goto_relative/CMakeLists.txt
@@ -2,21 +2,19 @@ get_filename_component(TEST_NAME "${CMAKE_CURRENT_SOURCE_DIR}" NAME)
 
 add_executable(test_${TEST_NAME}
   test.cpp
-  )
-
-ament_target_dependencies(test_${TEST_NAME}
-  rclcpp
-  mrs_lib
-  mrs_msgs
-  )
+)
 
 target_link_libraries(test_${TEST_NAME}
-    MrsUavTesting_TestGeneric
-  )
+  PRIVATE
+    mrs_uav_testing::mrs_uav_testing
+    rclcpp::rclcpp
+    mrs_lib::mrs_lib
+    ${mrs_msgs_TARGETS}
+)
 
-install(TARGETS
-  test_${TEST_NAME}
+install(
+  TARGETS test_${TEST_NAME}
   DESTINATION lib/${PROJECT_NAME}
-  )
+)
 
 add_ros_isolated_launch_test(test.py TIMEOUT 300)

--- a/test/takeoff/CMakeLists.txt
+++ b/test/takeoff/CMakeLists.txt
@@ -2,21 +2,19 @@ get_filename_component(TEST_NAME "${CMAKE_CURRENT_SOURCE_DIR}" NAME)
 
 add_executable(test_${TEST_NAME}
   test.cpp
-  )
-
-ament_target_dependencies(test_${TEST_NAME}
-  rclcpp
-  mrs_lib
-  mrs_msgs
-  )
+)
 
 target_link_libraries(test_${TEST_NAME}
-    MrsUavTesting_TestGeneric
-  )
+  PRIVATE
+    mrs_uav_testing::mrs_uav_testing
+    rclcpp::rclcpp
+    mrs_lib::mrs_lib
+    ${mrs_msgs_TARGETS}
+)
 
-install(TARGETS
-  test_${TEST_NAME}
+install(
+  TARGETS test_${TEST_NAME}
   DESTINATION lib/${PROJECT_NAME}
-  )
+)
 
 add_ros_isolated_launch_test(test.py TIMEOUT 300)


### PR DESCRIPTION
- increased minimum required version of CMake to 3.28
- renamed exported target to mrs_uav_testing::mrs_uav_testing
  - users can directly link against this target to use the library
  - projects no longer need to manually include mrs_uav_testing_INCLUDE_DIRS
- renamed the created static library to match the name of the project
- added explicit headers with cmake file set
- changed install location of headers
  - instead of being directly in the include directory, they are put in a subfolder to aid isolation
- removed unnecessary global include_directories
- changed uses of `ament_target_dependencies` to `target_link_libraries`